### PR TITLE
Revert files that paint Jira tickets

### DIFF
--- a/media/utils/DailySummary/Jira/addJiraTicketsToDailySummary.js
+++ b/media/utils/DailySummary/Jira/addJiraTicketsToDailySummary.js
@@ -14,13 +14,9 @@ const addJiraTicketsToDailySummary = (jiraTickets) => {
       </a>
       <span style="color: green">${ticket?.fields?.status?.name}</span>
     </div>
-    ${
-      ticket?.renderedFields?.description ? (
-        <div class="Box-body">${ticket?.renderedFields?.description}</div>
-      ) : (
-        ""
-      )
-    }
+    <div class="Box-body">
+      ${ticket?.renderedFields?.description}
+    </div>
     </div>
     <br/>
     `);

--- a/media/utils/addMostRelevantJiraTicket.js
+++ b/media/utils/addMostRelevantJiraTicket.js
@@ -13,13 +13,9 @@ const paintTickets = (tickets) => {
       </a>
       <span style="color: green">${ticket?.fields?.status?.name}</span>
     </div>
-    ${
-      ticket?.renderedFields?.description ? (
-        <div class="Box-body">${ticket?.renderedFields?.description}</div>
-      ) : (
-        ""
-      )
-    }
+    <div class="Box-body">
+      ${ticket?.renderedFields?.description}
+    </div>
     </div>
   `);
     }
@@ -50,3 +46,4 @@ const addMostRelevantJiraTicket = (jiraTickets) => {
 };
 
 export default addMostRelevantJiraTicket;
+


### PR DESCRIPTION
## Description
Both the dev and the prod version is broken for me. This change fixes this by reverting addJiraTicketsToDailySummary.js and addMostRelevantJiraTicket.js

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update  
- [ ] Chore: cleanup/renaming, etc  
- [ ] RFC  

## Notes
### Watermelon on prod
https://user-images.githubusercontent.com/8325094/199203726-a99a85c8-cff4-4341-845f-4ecd4460ec4e.mov

### Watermelon on this remote branch
https://user-images.githubusercontent.com/8325094/199203686-6a38ebf3-f110-4f7d-8b8c-3be30f18da33.mov

## Acceptance
- [x] I have read [the Contributing guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md) 
