### PR TITLE
Bugfix/wm 132 get code context other branch

### DIFF
--- a/media/main.js
+++ b/media/main.js
@@ -49,7 +49,7 @@ function handleMessage(message) {
       );
       addDailySummary({
         gitHubIssues: message.data.gitHubIssues,
-        jiraTickets: message.data.jiraTickets,
+        // jiraTickets: message.data.jiraTickets,
       });
       break;
     case "prs":
@@ -64,17 +64,18 @@ function handleMessage(message) {
         commitLink = `https://github.com/${message.owner}/${message.repo}/commit/`;
       }
       // blame table
-      addBlametoDoc(message.data.uniqueBlames, commitLink);
+      // addBlametoDoc(message.data.uniqueBlames, commitLink);
       // prs
       webviewDebugLogger(`Received prs: ${JSON.stringify(message.data)}`);
       addPRsToDoc(message.data.sortedPRs);
       // jira
       if (message.data?.mostRelevantJiraTickets) {
+        console.log("main.js line 73: ", mostRelevantJiraTickets);
         $("#mostRelevantJiraTicketHolder").empty();
         addMostRelevantJiraTickets(message.data.mostRelevantJiraTickets);
       }
       clampCodeBlocks();
-      addSlackThreads(message.data.relevantSlackThreads);
+      // addSlackThreads(message.data.relevantSlackThreads);
       break;
     case "error":
       webviewDebugLogger(`Received error: ${JSON.stringify(message.data)}`);

--- a/media/main.js
+++ b/media/main.js
@@ -69,11 +69,12 @@ function handleMessage(message) {
       webviewDebugLogger(`Received prs: ${JSON.stringify(message.data)}`);
       addPRsToDoc(message.data.sortedPRs);
       // jira
+      /*
       if (message.data?.mostRelevantJiraTickets) {
-        console.log("main.js line 73: ", mostRelevantJiraTickets);
         $("#mostRelevantJiraTicketHolder").empty();
         addMostRelevantJiraTickets(message.data.mostRelevantJiraTickets);
       }
+      */
       clampCodeBlocks();
       // addSlackThreads(message.data.relevantSlackThreads);
       break;

--- a/media/utils/removeLoading.js
+++ b/media/utils/removeLoading.js
@@ -1,6 +1,5 @@
 function removeLoading(errorTimeout) {
   clearTimeout(errorTimeout);
-  console.log("removeLoading.js: ", errorTimeout)
   $("#holders p").remove();
   $("#holders button").remove();
   $("#holders").append(`

--- a/media/utils/removeLoading.js
+++ b/media/utils/removeLoading.js
@@ -1,6 +1,6 @@
 function removeLoading(errorTimeout) {
   clearTimeout(errorTimeout);
-  console.log(errorTimeout)
+  console.log("removeLoading.js: ", errorTimeout)
   $("#holders p").remove();
   $("#holders button").remove();
   $("#holders").append(`

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -53,13 +53,13 @@ export async function activate(context: vscode.ExtensionContext) {
   let reporter = analyticsReporter();
   reporter?.sendTelemetryEvent("extensionActivated");
   let gitAPI = await getGitAPI();
-  debugLogger(`got gitAPI`);
+  debugLogger("got gitAPI");
 
   const provider = new WatermelonSidebar(context, reporter);
-  debugLogger(`created provider`);
+  debugLogger("created provider");
 
   let wmStatusBarItem = statusBarItem();
-  debugLogger(`created wmStatusBarItem`);
+  debugLogger("created wmStatusBarItem");
 
   context.subscriptions.push(
     // webview
@@ -83,7 +83,7 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.window.registerUriHandler({
       handleUri(uri) {
         // show a hello message
-        vscode.window.showInformationMessage("URI" + uri);
+        vscode.window.showInformationMessage(`URI${uri}`);
         const urlSearchParams = new URLSearchParams(uri.query);
         const params = Object.fromEntries(urlSearchParams.entries());
         context.secrets.store("watermelonToken", params.token);
@@ -196,24 +196,33 @@ export async function activate(context: vscode.ExtensionContext) {
         };
         const parsedMessage = parsedCommitObject.message;
         // Jira
-        const mostRelevantJiraTickets =
-          (await getMostRelevantJiraTickets({
-            user: session.account.label,
-            prTitle: sortedPRs[0].title || parsedMessage,
-          })) || {};
+        // console.log("extension.ts line: 205 ", {
+        //   user: session.account.label,
+        //   prTitle: sortedPRs[0].title || parsedMessage,
+        //   });
+        // const mostRelevantJiraTickets =
+        //   (await getMostRelevantJiraTickets({
+        //     user: session.account.label,
+        //     prTitle: sortedPRs[0].title || parsedMessage,
+        //   })) || {};
         // Slack
-        const relevantSlackThreads = await searchMessagesByText({
-          user: session.account.label,
-          email: session.account.label,
-          text: sortedPRs[0].title || parsedMessage,
-        });
+        // console.log("extension.ts line: 205 ", {
+        //   user: session.account.label,
+        //   email: session.account.label,
+        //   text: sortedPRs[0].title || parsedMessage,
+        //   })
+        // const relevantSlackThreads = await searchMessagesByText({
+        //   user: session.account.label,
+        //   email: session.account.label,
+        //   text: sortedPRs[0].title || parsedMessage,
+        // });
         provider.sendMessage({
           command: "prs",
           data: {
             sortedPRs,
             uniqueBlames,
-            mostRelevantJiraTickets,
-            relevantSlackThreads,
+            // mostRelevantJiraTickets,
+            // relevantSlackThreads,
           },
         });
       } else {
@@ -294,10 +303,10 @@ export async function activate(context: vscode.ExtensionContext) {
           isStarred,
         },
       });
-      const jiraTickets = await getAssignedJiraTickets({
-        user: session.account.label,
-      });
-      debugLogger(`jiraTickets: ${jiraTickets}`);
+      // const jiraTickets = await getAssignedJiraTickets({
+      //   user: session.account.label,
+      // });
+      // debugLogger(`jiraTickets: ${jiraTickets}`);
 
       let gitHubIssues = await getGitHubDailySummary({
         owner: owner || "",
@@ -308,7 +317,8 @@ export async function activate(context: vscode.ExtensionContext) {
       debugLogger(`gitHubIssues: ${JSON.stringify(gitHubIssues)}`);
       provider.sendMessage({
         command: "dailySummary",
-        data: { gitHubIssues, jiraTickets },
+        // data: { gitHubIssues, jiraTickets },
+        data: { gitHubIssues },
       });
     } else {
       let uniqueBlames = await getBlame(gitAPI, startLine, endLine);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -83,7 +83,6 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.window.registerUriHandler({
       handleUri(uri) {
         // show a hello message
-        vscode.window.showInformationMessage(`URI${uri}`);
         const urlSearchParams = new URLSearchParams(uri.query);
         const params = Object.fromEntries(urlSearchParams.entries());
         context.secrets.store("watermelonToken", params.token);
@@ -196,26 +195,20 @@ export async function activate(context: vscode.ExtensionContext) {
         };
         const parsedMessage = parsedCommitObject.message;
         // Jira
-        // console.log("extension.ts line: 205 ", {
-        //   user: session.account.label,
-        //   prTitle: sortedPRs[0].title || parsedMessage,
-        //   });
-        // const mostRelevantJiraTickets =
-        //   (await getMostRelevantJiraTickets({
-        //     user: session.account.label,
-        //     prTitle: sortedPRs[0].title || parsedMessage,
-        //   })) || {};
+        /*
+        const mostRelevantJiraTickets =
+          (await getMostRelevantJiraTickets({
+            user: session.account.label,
+            prTitle: sortedPRs[0].title || parsedMessage,
+          })) || {};
+        */
         // Slack
-        // console.log("extension.ts line: 205 ", {
-        //   user: session.account.label,
-        //   email: session.account.label,
-        //   text: sortedPRs[0].title || parsedMessage,
-        //   })
-        // const relevantSlackThreads = await searchMessagesByText({
-        //   user: session.account.label,
-        //   email: session.account.label,
-        //   text: sortedPRs[0].title || parsedMessage,
-        // });
+        /*
+        const relevantSlackThreads = await searchMessagesByText({
+          user: session.account.label,
+          email: session.account.label,
+          text: sortedPRs[0].title || parsedMessage,
+        });
         provider.sendMessage({
           command: "prs",
           data: {
@@ -225,6 +218,7 @@ export async function activate(context: vscode.ExtensionContext) {
             // relevantSlackThreads,
           },
         });
+        */
       } else {
         vscode.commands.executeCommand("watermelon.multiSelect");
         arrayOfSHAs = await getSHAArray(

--- a/src/utils/vscode/getInitialHTML.ts
+++ b/src/utils/vscode/getInitialHTML.ts
@@ -109,7 +109,7 @@ export default function getInitialHTML(
        <a href="https://github.com/watermelontools/wm-extension/issues">Send an Issue</a>
        </div>
        <div class="Box-row Box-row--hover-gray">
-       <a href="discord.gg/H4AE6b9442">Join us on Discord</a>
+       <a href="https://discord.com/invite/H4AE6b9442">Join us on Discord</a>
      </div>
       </details>
      </div>


### PR DESCRIPTION
## Description
This PR allows us to go back to running customer demos and user interviews. 

Jira and Slack functionalities where removed by commenting their blocks of code. Daily summary removal is still pending. 

This PR will also allow us to start working on git system differentiation and context summarization. 

A caveat is that the extension sometimes brings the user back to the Watermelon sidebar without clicking our icon (as seen on the video below), but the gains are way bigger. It's a tradeoff worth doing. 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update  
- [ ] Chore: cleanup/renaming, etc  
- [ ] RFC  

## Notes
https://user-images.githubusercontent.com/8325094/211878061-722378ef-03d6-4fd7-bdaf-6e0b2d48e123.mov

## Acceptance
- [x] I have read [the Contributing guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md) 
