### PR TITLE
Report getCodeContext event on the telemetry

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -77,7 +77,8 @@ export class WatermelonTreeDataProvider
     const items: ContextItem[] = [];
     let gitAPI = await getGitAPI();
     debugLogger(`got gitAPI`);
-    let repoInfo = await getRepoInfo({});
+    let reporter = analyticsReporter();
+    let repoInfo = await getRepoInfo({ reporter });
     repoSource = repoInfo?.source;
     repo = repoInfo?.repo;
     owner = repoInfo?.owner;
@@ -169,7 +170,6 @@ export class WatermelonTreeDataProvider
       results.forEach((result) => {
         items.push(...result);
       });
-      let reporter = analyticsReporter();
       reporter?.sendTelemetryEvent("getCodeContext");
       return items;
     } else {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -169,6 +169,8 @@ export class WatermelonTreeDataProvider
       results.forEach((result) => {
         items.push(...result);
       });
+      let reporter = analyticsReporter();
+      reporter?.sendTelemetryEvent("getCodeContext");
       return items;
     } else {
       vscode.commands.executeCommand("watermelon.multiSelect");


### PR DESCRIPTION
## Description
We forgot to add a telemetry event for the new get code context architecture. 

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update  
- [x] Chore: cleanup/renaming, etc  
- [ ] RFC 
 
## Notes
Here's the event getting correctly reported for me 
<img width="1056" alt="Screen Shot 2023-02-09 at 12 14 03 PM" src="https://user-images.githubusercontent.com/8325094/217888445-e3f38fc0-5684-4640-aaea-6578298d0de2.png">

## Acceptance
- [x] I have read [the Contributing guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md) 
