### PR TITLE
Try adding jira and slack info to gpt prompt

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -147,6 +147,9 @@ export class WatermelonTreeDataProvider
         setLoggedIn(false);
         return items;
       }
+      console.log("jiraitems title: ", sortedPRs[0]?.jiraItems?.[0]?.title);
+      console.log("jiraitems body: ", sortedPRs[0]?.jiraItems?.[0]?.body);
+      console.log("slackitems title: ", sortedPRs[0]?.slackItems?.[0]?.title);
       let itemPromises = [
         getHubLabBucketItems(issuesWithTitlesAndGroupedComments, repoSource),
         getGitItems(uniqueBlames),
@@ -158,9 +161,13 @@ export class WatermelonTreeDataProvider
           sortedPRs[0]?.title || parsedMessage,
           session.account.label
         ),
+        // jira ticket body
         getCodeContextSummary(
           sortedPRs[0]?.title || parsedMessage,
           sortedPRs[0]?.body || parsedCommitObject.body,
+          //jiraTicketTitle,
+          //jiraTicketBody,
+          //slackThread,
           selectedBlockOfCode,
           session.account.label
         ),

--- a/src/utils/treeview/getCodeContextSummary.ts
+++ b/src/utils/treeview/getCodeContextSummary.ts
@@ -8,6 +8,9 @@ export const getCodeContextSummary = async (
   prTitle: string,
   prBody: string,
   blockOfCode: string,
+  ticketTitle: string, 
+  ticketBody: string,
+  threadBody: string,
   userEmail: string
 ) => {
   let items: ContextItem[] = [];
@@ -17,6 +20,9 @@ export const getCodeContextSummary = async (
       pr_title: prTitle,
       pr_body: prBody,
       block_of_code: blockOfCode,
+      ticket_title: ticketTitle,
+      ticket_body: ticketBody,
+      thread_body: threadBody,
       user_email: userEmail,
     })
     .then((res) => res.data)


### PR DESCRIPTION
## Description


## Type of change
<!--  Please delete options that are not relevant or write your own. -->
- [ ] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update  
- [ ] Chore: cleanup/renaming, etc  
- [ ] RFC
  
## Notes
I am trying to access jira and Slack info on line 164, the same way that we're accessing `sortedPRs[ ]` but such is accessed with the` getJiraItems( ) `function. In line 104 we get git issues. How can we do the same thing for Jira and Slack info> 

## Acceptance
- [x] I have read [the Contributing guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md) 
