### PR TITLE
Add 2 second timeout to the hover telemetry event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the "watermelon" extension will be documented in this fil
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [2.0.3]
+- Hover telemetry event gets measured with a 2 second time-out
+
 ## [2.0.2]
 
 - Gitlab now displays MR comments

--- a/src/utils/components/hover.ts
+++ b/src/utils/components/hover.ts
@@ -74,7 +74,9 @@ const hover = ({ reporter }: { reporter: TelemetryReporter | null }) => {
       content.supportHtml = true;
       content.isTrusted = true;
       content.supportThemeIcons = true;
-      reporter?.sendTelemetryEvent("hover");
+      setTimeout(() => {
+        reporter?.sendTelemetryEvent("hover");
+      }, 2000); 
       return new vscode.Hover(content);
     },
   });

--- a/src/utils/components/hover.ts
+++ b/src/utils/components/hover.ts
@@ -75,7 +75,7 @@ const hover = ({ reporter }: { reporter: TelemetryReporter | null }) => {
       content.isTrusted = true;
       content.supportThemeIcons = true;
       setTimeout(() => {
-        reporter?.sendTelemetryEvent("hover");
+        reporter?.sendTelemetryEvent("strictHover");
       }, 2000); 
       return new vscode.Hover(content);
     },


### PR DESCRIPTION
## Description
We need to measure hover as active usage more strictly. Are they getting rid of it? Or are they reading it? 

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update  
- [x] Chore: cleanup/renaming, etc  
- [ ] RFC 

 
## Notes
Our metrics will go down, but we will be more disciplined with the definition of PMF

## Acceptance
- [x] I have read [the Contributing guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md) 
