### PR TITLE
Don't send code to gpt prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the "watermelon" extension will be documented in this fil
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [2.0.4]
+- We don't send code to our server anymore
 ## [2.0.3]
 - Hover telemetry event gets measured with a 2 second time-out
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -127,22 +127,6 @@ export class WatermelonTreeDataProvider
       };
       const parsedMessage = parsedCommitObject.message;
 
-      // get the start and end line of the selected block of code
-      let selectedStartLine = vscode.window.activeTextEditor?.selection.start;
-      let selectedEndLine = vscode.window.activeTextEditor?.selection.end;
-
-      // get the text of the selected block of code
-      let selectedBlockOfCode = "";
-
-      if (selectedStartLine && selectedEndLine) {
-        let selectedText = vscode.window.activeTextEditor?.document.getText(
-          new vscode.Range(selectedStartLine, selectedEndLine)
-        );
-
-        let selectedCode = selectedText || "";
-        selectedBlockOfCode = selectedCode.replace(/(\r\n|\n|\r)/gm, "");
-      }
-
       debugLogger(`parsedMessage: ${parsedMessage}`);
       if (!session) {
         setLoggedIn(false);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -162,7 +162,6 @@ export class WatermelonTreeDataProvider
         getCodeContextSummary(
           sortedPRs[0]?.title || parsedMessage,
           sortedPRs[0]?.body || parsedCommitObject.body,
-          selectedBlockOfCode,
           session.account.label
         ),
       ];

--- a/src/utils/treeview/getCodeContextSummary.ts
+++ b/src/utils/treeview/getCodeContextSummary.ts
@@ -7,7 +7,6 @@ import analyticsReporter from "../vscode/reporter";
 export const getCodeContextSummary = async (
   prTitle: string,
   prBody: string,
-  blockOfCode: string,
   userEmail: string
 ) => {
   let items: ContextItem[] = [];
@@ -16,7 +15,6 @@ export const getCodeContextSummary = async (
     .post(`${backendURL}/api/openai/summarizeCodeContext`, {
       pr_title: prTitle,
       pr_body: prBody,
-      block_of_code: blockOfCode,
       user_email: userEmail,
     })
     .then((res) => res.data)


### PR DESCRIPTION
## Description
We have to remove selected block of code from the prompt sent to GPT because
1. We lose our transparency value prop
2. We confuse GPT, and it explains syntax (even if we tell it to not do so). 
3. There is no value on leaving it there other than explaining syntax (not our vision). 

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update  
- [x] Chore: cleanup/renaming, etc  
- [ ] RFC  

## Notes
Depends on the backend PR that removes this from the prompt

## Acceptance
- [x] I have read [the Contributing guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md) 
