### PR TITLE
Chore/measure hover well

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "watermelon-tools",
   "description": "Watermelon, find all the historical context of your code",
-  "version": "2.0.2",
+  "version": "2.0.4",
   "publisher": "WatermelonTools",
   "displayName": "Watermelon",
   "private": true,

--- a/src/utils/components/hover.ts
+++ b/src/utils/components/hover.ts
@@ -74,9 +74,7 @@ const hover = ({ reporter }: { reporter: TelemetryReporter | null }) => {
       content.supportHtml = true;
       content.isTrusted = true;
       content.supportThemeIcons = true;
-      setTimeout(() => {
-        reporter?.sendTelemetryEvent("strictHover");
-      }, 2000); 
+      reporter?.sendTelemetryEvent("hover"); 
       return new vscode.Hover(content);
     },
   });


### PR DESCRIPTION
## Description
Because of how TypeScript's setTimeout( ) works, we couldn't measure the hover telemetry event as the person reading the box for 2 seconds. Instead, the telemetry event simply got sent 2s later, regardless if the hover context box was removed or not. 

Changing the name back to 'hover' also allows us to have continout telemetry for cohort analysis among other things. 

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update  
- [x] Chore: cleanup/renaming, etc  
- [ ] RFC  


## Acceptance
- [x] I have read [the Contributing guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md) 
